### PR TITLE
feat: add block replayer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,7 +834,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 name = "beacon-lib"
 version = "0.1.0"
 dependencies = [
+ "state_processing",
  "tracing",
+ "types",
 ]
 
 [[package]]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -5,3 +5,5 @@ edition = "2021"
 
 [dependencies]
 tracing = { version = "0.1" }
+lighthouse-state-processing = { git = "https://github.com/pawanjay176/lighthouse", package = "state_processing", rev = "def2498bc4114b4bd7933cf3bb9a45a555d24ede" } # Lighthouse for Mekong 
+lighthouse-types.workspace = true

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,5 +1,30 @@
+use lighthouse_state_processing::{BlockReplayError, BlockReplayer};
+use lighthouse_types::{BeaconState, BlindedPayload, EthSpec, SignedBeaconBlock, Slot};
+
+use std::array::IntoIter;
+
 // TODO: will be replaced with the actual beacon processor
 pub fn isomorphic_function(n: u32) -> u32 {
     tracing::info!("isomorphic_function {}", n);
     n
+}
+
+pub fn replay_beacon_blocks<E: EthSpec>(
+    start_state: BeaconState<E>,
+    blocks: Vec<SignedBeaconBlock<E, BlindedPayload<E>>>,
+    target_slot: Slot,
+) -> BeaconState<E> {
+    tracing::info!(
+        "Replay beacon block from slot {} to slot {}",
+        start_state.slot(),
+        target_slot
+    );
+    let spec = E::default_spec();
+    let state = BlockReplayer::<E, BlockReplayError, IntoIter<_, 0>>::new(start_state, &spec)
+        .no_signature_verification()
+        .apply_blocks(blocks, Some(target_slot))
+        .expect("Block replay failed")
+        .into_state();
+
+    state
 }

--- a/script/src/bin/beacon_client/mod.rs
+++ b/script/src/bin/beacon_client/mod.rs
@@ -4,7 +4,7 @@ use lighthouse_eth2::{
     types::{BlockId, StateId},
     BeaconNodeHttpClient, SensitiveUrl, Timeouts,
 };
-use lighthouse_types::{MainnetEthSpec, SignedBeaconBlock, Slot};
+use lighthouse_types::{BlindedPayload, MainnetEthSpec, SignedBeaconBlock, Slot};
 
 pub struct BeaconClient {
     client: BeaconNodeHttpClient,
@@ -36,10 +36,11 @@ impl BeaconClient {
     pub async fn get_beacon_block(
         &self,
         slot: u64,
-    ) -> Result<Option<SignedBeaconBlock<MainnetEthSpec>>, String> {
+    ) -> Result<Option<SignedBeaconBlock<MainnetEthSpec, BlindedPayload<MainnetEthSpec>>>, String>
+    {
         let block = self
             .client
-            .get_beacon_blocks::<MainnetEthSpec>(BlockId::Slot(slot.into()))
+            .get_beacon_blinded_blocks::<MainnetEthSpec>(BlockId::Slot(slot.into()))
             .await
             .map_err(|e| format!("Failed to get beacon block: {:?}", e))?;
 
@@ -57,7 +58,8 @@ impl BeaconClient {
         &self,
         start: u64,
         end: u64,
-    ) -> Result<Vec<SignedBeaconBlock<MainnetEthSpec>>, String> {
+    ) -> Result<Vec<SignedBeaconBlock<MainnetEthSpec, BlindedPayload<MainnetEthSpec>>>, String>
+    {
         let mut blocks = Vec::new();
 
         for slot in start..=end {


### PR DESCRIPTION
Currently, `cargo build` doesn't work as we need some patches to compile cryptographic crates on RISC-V.